### PR TITLE
fix(directive): ensure language and source are non-falsy

### DIFF
--- a/src/highlightJs.directive.ts
+++ b/src/highlightJs.directive.ts
@@ -18,7 +18,7 @@ export class HighlightJsDirective implements OnChanges {
   constructor(@Inject(HIGHLIGHT_JS) private hljs) {} //tslint:disable-line
 
   ngOnChanges(changes: SimpleChanges): void {
-    if (changes['source'] || changes['language']) {
+    if ((changes['source'] || changes['language']) && this.language && this.source) {
       this.highlightedCode = this.hljs.highlight(this.language, this.source).value;
     }
   }


### PR DESCRIPTION
Without this fix on the latest version and highlight.js, I get this error:

```
ERROR TypeError: Cannot read property 'substr' of undefined
    at Object.highlight (highlight.js:518)
    at HighlightJsDirective.webpackJsonp.../../../../angular-highlight-js/dist/esm/src/highlightJs.directive.js.HighlightJsDirective.ngOnChanges (highlightJs.directive.js:9)
    at checkAndUpdateDirectiveInline (core.es5.js:10840)
    at checkAndUpdateNodeInline (core.es5.js:12341)
    at checkAndUpdateNode (core.es5.js:12284)
    at debugCheckAndUpdateNode (core.es5.js:13141)
    at debugCheckDirectivesFn (core.es5.js:13082)
    at Object.eval [as updateDirectives] (AppComponent.html:13)
    at Object.debugUpdateDirectives [as updateDirectives] (core.es5.js:13067)
    at checkAndUpdateView (core.es5.js:12251)
```

My use follows the documentation and the demo.